### PR TITLE
add new listings language definitions

### DIFF
--- a/listings.tex
+++ b/listings.tex
@@ -1,0 +1,54 @@
+% The language definitions below require the following packages:
+%
+%     \usepackage{xcolor}
+%     \usepackage{relsize}
+%     \usepackage{courier}
+%
+% When the python or clingo language is given, tex code can be embedded
+% escaping it in `#( ... #)`, which is treated like a comment in Python.
+% Furthermore, for logic programs the character sequence is `%%` is not output.
+% This can be used to add labels at the end of lines. For example, in a logic
+% program one can write
+%
+%     H :- B.%%#( \label{lst:rule} #)
+%
+% to refer to the rule from the document without having to worry about changing
+% line numbers when refactoring. The annotated program will still be runnable
+% with clingo.
+
+% Attention hack! Better alternatives welcome!
+\newcommand{\Underscore}{\textscale{1.3}{\textunderscore}}
+
+\lstdefinelanguage{clingo}{%
+  basicstyle=\ttfamily,%
+  keywordstyle=[1]\bfseries,%
+  keywordstyle=[2]\bfseries,%
+  keywordstyle=[3]\bfseries,%
+  showstringspaces=false,%
+  literate={_}{\Underscore}1 {\%\%}{}0,%
+  escapeinside={\#(}{\#)},%
+  alsoletter={\#,\&},%
+  keywords=[1]{not,from,import,def,if,else,elif,return,while,break,and,or,for,in,del,and,class,with,as,is},%
+  keywords=[2]{\#const,\#show,\#minimize,\#base,\#theory,\#count,\#external,\#program,\#script,\#end,\#heuristic,\#edge,\#project,\#show,\#sum},%
+  keywords=[3]{&,&dom,&sum,&diff,&show},%
+  morecomment=[l]{\#\ },%
+  morecomment=[l]{\%\ },%
+  morestring=[b]",%
+  stringstyle={\itshape},%
+  commentstyle={\color{darkgray}}%
+}
+
+\lstdefinelanguage{python}{%
+  basicstyle=\ttfamily,%
+  keywordstyle=[1]\bfseries,%
+  showstringspaces=false,%
+  literate={_}{\Underscore}{1},%
+  escapeinside={\#(}{\#)},%
+  alsoletter={\#,\&},%
+  keywords=[1]{not,from,import,def,if,else,elif,return,while,break,and,or,for,in,del,and,class,with,as,is},%
+  morecomment=[l]{\#\ },%
+  morestring=[b]",%
+  stringstyle={\itshape},%
+  commentstyle={\color{darkgray}}%
+}
+

--- a/listings.tex
+++ b/listings.tex
@@ -43,7 +43,7 @@
   literate={_}{\Underscore}1 {\%\%}{}0,%
   escapeinside={\#(}{\#)},%
   alsoletter={\#,\&},%
-  keywords=[1]{not,from,import,def,if,else,elif,return,while,break,and,or,for,in,del,and,class,with,as,is},%
+  keywords=[1]{not,from,import,def,if,else,elif,return,while,break,and,or,for,in,del,and,class,with,as,is,yield,async},%
   keywords=[2]{\#const,\#show,\#minimize,\#base,\#theory,\#count,\#external,\#program,\#script,\#end,\#heuristic,\#edge,\#project,\#show,\#sum},%
   keywords=[3]{&,&dom,&sum,&diff,&show},%
   morecomment=[l]{\#\ },%
@@ -60,7 +60,7 @@
   literate={_}{\Underscore}{1},%
   escapeinside={\#(}{\#)},%
   alsoletter={\#,\&},%
-  keywords=[1]{not,from,import,def,if,else,elif,return,while,break,and,or,for,in,del,and,class,with,as,is},%
+  keywords=[1]{not,from,import,def,if,else,elif,return,while,break,and,or,for,in,del,and,class,with,as,is,yield,async},%
   morecomment=[l]{\#\ },%
   morestring=[b]",%
   stringstyle={\itshape},%

--- a/listings.tex
+++ b/listings.tex
@@ -1,8 +1,24 @@
 % The language definitions below require the following packages:
 %
+%     \usepackage{courier}
 %     \usepackage{xcolor}
 %     \usepackage{relsize}
-%     \usepackage{courier}
+%
+%     \input{listings}
+%     \renewcommand{\Underscore}{\textscale{1}{\textunderscore}}
+%
+% Without extra packages I had to provide an alternative underscore definition
+% to get decent looking underscores.
+%
+% As an alternative to courier, it is also possible to use the `lmodern`
+% package.
+%
+%     \usepackage[T1]{fontenc}
+%     \usepackage{lmodern}
+%     \usepackage{xcolor}
+%     \usepackage{relsize}
+%
+%     \input{listings}
 %
 % When the python or clingo language is given, tex code can be embedded
 % escaping it in `#( ... #)`, which is treated like a comment in Python.
@@ -16,8 +32,7 @@
 % line numbers when refactoring. The annotated program will still be runnable
 % with clingo.
 
-% Attention hack! Better alternatives welcome!
-\newcommand{\Underscore}{\textscale{1.3}{\textunderscore}}
+\providecommand{\Underscore}{\textunderscore}
 
 \lstdefinelanguage{clingo}{%
   basicstyle=\ttfamily,%


### PR DESCRIPTION
This adds listings language definitions for clingo and python. To use them, either the courier or lmodern package has to be used. The latter provides better looking and more comprehensive fonts but publishers might have a problem with not using the default fonts. See the comments at the beginning of the `listings.tex` file for information how to use either of the two packages.